### PR TITLE
fix(meta): Fix map merge for meta.

### DIFF
--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -1052,13 +1052,15 @@ func flattenModelMeta(ctx context.Context, data map[string]any) (modelMetaState,
 
 	additional := copyStringAnyMap(data)
 
+	// these two should always be deleted, even if they are nil
+	delete(additional, "profile_image_url")
+	delete(additional, "description")
+
 	if value, ok := toStringValue(data["profile_image_url"]); ok {
 		state.ProfileImageURL = types.StringValue(value)
-		delete(additional, "profile_image_url")
 	}
 	if value, ok := toStringValue(data["description"]); ok {
 		state.Description = types.StringValue(value)
-		delete(additional, "description")
 	}
 	if raw, ok := data["capabilities"]; ok {
 		switch v := raw.(type) {
@@ -1186,19 +1188,11 @@ func mergeStringAnyMaps(primary, secondary map[string]any) map[string]any {
 		return nil
 	}
 
-	if primary == nil {
-		result := make(map[string]any, len(secondary))
-		for k, v := range secondary {
-			result[k] = v
-		}
-		return result
-	}
-
 	result := make(map[string]any, len(primary)+len(secondary))
-	for k, v := range primary {
+	for k, v := range secondary {
 		result[k] = v
 	}
-	for k, v := range secondary {
+	for k, v := range primary {
 		result[k] = v
 	}
 


### PR DESCRIPTION
In my usage, I tried to set a description from null to a string value. Opentofu reported that there was an error in the provider because the requested change did not match the final state.

This stems from two problems.

1. The `toStringValue` returns `false` for `ok` when the original is `nil`. This means that a `null` description is left in the "additional" json data for `description` and `profile_image_url` (though the latter seems to default to non-nil).
2. The merge function between maps prefers the secondary over the primary, which I think is incorrect.

Fixing either of these problems would fix the error, but I think both should be fixed. Removing the key from the additional meta also fixes a strange looking state where `description: null` appears twice for the model, once in the meta and once in the additional meta.

This also removes a superfluous case for when the primary map is nil, since a nil map works just fine to iterate over.

NOTE: Codex identified these problems, and proposed the fix to the `mergeStringAnyMaps` function, but I provided the change in the `flattenModelMeta`, as I surmised this is the correct fix (just fixing the merge would only fix the symptom).

Also, I am brand new to golang, so if I did something incorrect, please let me know.