### PR TITLE
feat: migrate access_control to access_grants API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp/
 dist/
 coverage.out
 .idea/
+terraform-provider-openwebui

--- a/internal/client/access.go
+++ b/internal/client/access.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 )
 
 // AccessGrant represents a single access grant returned by the API.
@@ -25,28 +26,32 @@ func BuildGroupGrants(readIDs, writeIDs []string) []AccessGrant {
 		return []AccessGrant{}
 	}
 
-	writeSet := make(map[string]struct{}, len(writeIDs))
-	for _, id := range writeIDs {
-		writeSet[id] = struct{}{}
+	dedupe := func(ids []string) []string {
+		seen := make(map[string]struct{}, len(ids))
+		out := make([]string, 0, len(ids))
+		for _, id := range ids {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+		sort.Strings(out)
+		return out
 	}
 
-	readSet := make(map[string]struct{}, len(readIDs)+len(writeIDs))
-	for _, id := range readIDs {
-		readSet[id] = struct{}{}
-	}
-	for _, id := range writeIDs {
-		readSet[id] = struct{}{}
-	}
+	writeOrdered := dedupe(writeIDs)
+	readOrdered := dedupe(append(append([]string{}, readIDs...), writeIDs...))
 
-	grants := make([]AccessGrant, 0, len(readSet)+len(writeSet))
-	for id := range readSet {
+	grants := make([]AccessGrant, 0, len(readOrdered)+len(writeOrdered))
+	for _, id := range readOrdered {
 		grants = append(grants, AccessGrant{
 			PrincipalType: "group",
 			PrincipalID:   id,
 			Permission:    "read",
 		})
 	}
-	for id := range writeSet {
+	for _, id := range writeOrdered {
 		grants = append(grants, AccessGrant{
 			PrincipalType: "group",
 			PrincipalID:   id,

--- a/internal/client/access.go
+++ b/internal/client/access.go
@@ -1,0 +1,133 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// AccessGrant represents a single access grant returned by the API.
+type AccessGrant struct {
+	ID            string `json:"id,omitempty"`
+	ResourceType  string `json:"resource_type,omitempty"`
+	ResourceID    string `json:"resource_id,omitempty"`
+	PrincipalType string `json:"principal_type"`
+	PrincipalID   string `json:"principal_id"`
+	Permission    string `json:"permission"`
+	CreatedAt     int64  `json:"created_at,omitempty"`
+}
+
+// BuildGroupGrants converts read/write group ID lists into a flat slice of
+// AccessGrant objects. Write implies read.
+func BuildGroupGrants(readIDs, writeIDs []string) []AccessGrant {
+	if len(readIDs) == 0 && len(writeIDs) == 0 {
+		return []AccessGrant{}
+	}
+
+	writeSet := make(map[string]struct{}, len(writeIDs))
+	for _, id := range writeIDs {
+		writeSet[id] = struct{}{}
+	}
+
+	readSet := make(map[string]struct{}, len(readIDs)+len(writeIDs))
+	for _, id := range readIDs {
+		readSet[id] = struct{}{}
+	}
+	for _, id := range writeIDs {
+		readSet[id] = struct{}{}
+	}
+
+	grants := make([]AccessGrant, 0, len(readSet)+len(writeSet))
+	for id := range readSet {
+		grants = append(grants, AccessGrant{
+			PrincipalType: "group",
+			PrincipalID:   id,
+			Permission:    "read",
+		})
+	}
+	for id := range writeSet {
+		grants = append(grants, AccessGrant{
+			PrincipalType: "group",
+			PrincipalID:   id,
+			Permission:    "write",
+		})
+	}
+
+	return grants
+}
+
+// ExtractGroupIDs returns unique group principal IDs holding the named permission.
+func ExtractGroupIDs(grants []AccessGrant, permission string) []string {
+	if len(grants) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var ids []string
+	for _, g := range grants {
+		if g.PrincipalType != "group" {
+			continue
+		}
+		if g.Permission != permission {
+			continue
+		}
+		if _, ok := seen[g.PrincipalID]; ok {
+			continue
+		}
+		seen[g.PrincipalID] = struct{}{}
+		ids = append(ids, g.PrincipalID)
+	}
+
+	return ids
+}
+
+type accessUpdateResponse struct {
+	AccessGrants []AccessGrant `json:"access_grants"`
+}
+
+// UpdateModelAccess replaces the access grants on a model and returns the new grants.
+func (c *Client) UpdateModelAccess(ctx context.Context, id string, grants []AccessGrant) ([]AccessGrant, error) {
+	body := map[string]any{
+		"id":            id,
+		"access_grants": grants,
+	}
+	var resp accessUpdateResponse
+	if err := c.do(ctx, http.MethodPost, "models/model/access/update", nil, body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.AccessGrants, nil
+}
+
+// UpdateKnowledgeAccess replaces the access grants on a knowledge entry.
+func (c *Client) UpdateKnowledgeAccess(ctx context.Context, id string, grants []AccessGrant) ([]AccessGrant, error) {
+	body := map[string]any{"access_grants": grants}
+	path := fmt.Sprintf("knowledge/%s/access/update", url.PathEscape(id))
+	var resp accessUpdateResponse
+	if err := c.do(ctx, http.MethodPost, path, nil, body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.AccessGrants, nil
+}
+
+// UpdatePromptAccess replaces the access grants on a prompt (path is by prompt id).
+func (c *Client) UpdatePromptAccess(ctx context.Context, promptID string, grants []AccessGrant) ([]AccessGrant, error) {
+	body := map[string]any{"access_grants": grants}
+	path := fmt.Sprintf("prompts/id/%s/access/update", url.PathEscape(promptID))
+	var resp accessUpdateResponse
+	if err := c.do(ctx, http.MethodPost, path, nil, body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.AccessGrants, nil
+}
+
+// UpdateToolAccess replaces the access grants on a tool.
+func (c *Client) UpdateToolAccess(ctx context.Context, id string, grants []AccessGrant) ([]AccessGrant, error) {
+	body := map[string]any{"access_grants": grants}
+	path := fmt.Sprintf("tools/id/%s/access/update", url.PathEscape(id))
+	var resp accessUpdateResponse
+	if err := c.do(ctx, http.MethodPost, path, nil, body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.AccessGrants, nil
+}

--- a/internal/client/knowledge.go
+++ b/internal/client/knowledge.go
@@ -12,6 +12,7 @@ type KnowledgeForm struct {
 	Name          string         `json:"name"`
 	Description   string         `json:"description"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 	Data          map[string]any `json:"data,omitempty"`
 	Meta          map[string]any `json:"meta,omitempty"`
 }
@@ -38,6 +39,7 @@ type KnowledgeResponse struct {
 	CreatedAt     int64          `json:"created_at"`
 	UpdatedAt     int64          `json:"updated_at"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 	Data          map[string]any `json:"data,omitempty"`
 	Meta          map[string]any `json:"meta,omitempty"`
 	Files         []FileModel    `json:"files,omitempty"`
@@ -52,6 +54,7 @@ type KnowledgeFilesResponse struct {
 	CreatedAt     int64          `json:"created_at"`
 	UpdatedAt     int64          `json:"updated_at"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 	Data          map[string]any `json:"data,omitempty"`
 	Meta          map[string]any `json:"meta,omitempty"`
 	Files         []FileModel    `json:"files"`
@@ -87,6 +90,7 @@ type KnowledgeListItem struct {
 	CreatedAt     int64          `json:"created_at"`
 	UpdatedAt     int64          `json:"updated_at"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 	Data          map[string]any `json:"data,omitempty"`
 	Meta          map[string]any `json:"meta,omitempty"`
 }

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -27,6 +27,7 @@ type ModelResponse struct {
 	BaseModelID   *string        `json:"base_model_id,omitempty"`
 	IsActive      bool           `json:"is_active"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 	CreatedAt     int64          `json:"created_at"`
 	UpdatedAt     int64          `json:"updated_at"`
 }
@@ -66,5 +67,6 @@ func (c *Client) UpdateModel(ctx context.Context, id string, form ModelForm) (*M
 // DeleteModel removes a model by identifier.
 func (c *Client) DeleteModel(ctx context.Context, id string) error {
 	query := url.Values{"id": []string{id}}
-	return c.do(ctx, http.MethodPost, "models/model/delete", query, nil, nil)
+	body := map[string]string{"id": id}
+	return c.do(ctx, http.MethodPost, "models/model/delete", query, body, nil)
 }

--- a/internal/client/prompts.go
+++ b/internal/client/prompts.go
@@ -28,16 +28,19 @@ type PromptForm struct {
 	Title         string         `json:"title"`
 	Content       string         `json:"content"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 }
 
 // PromptModel is returned by the prompt endpoints.
 type PromptModel struct {
+	ID            string         `json:"id,omitempty"`
 	Command       string         `json:"command"`
 	Title         string         `json:"title"`
 	Content       string         `json:"content"`
 	Timestamp     int64          `json:"timestamp"`
 	UserID        string         `json:"user_id"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 }
 
 // CreatePrompt registers a new prompt.

--- a/internal/client/tools.go
+++ b/internal/client/tools.go
@@ -19,6 +19,7 @@ type ToolForm struct {
 	Content       string         `json:"content"`
 	Meta          ToolMeta       `json:"meta"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 }
 
 // ToolResponse captures basic tool details.
@@ -28,6 +29,7 @@ type ToolResponse struct {
 	Name          string         `json:"name"`
 	Meta          ToolMeta       `json:"meta"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 	UpdatedAt     int64          `json:"updated_at"`
 	CreatedAt     int64          `json:"created_at"`
 }
@@ -41,6 +43,7 @@ type ToolModel struct {
 	Specs         []map[string]any `json:"specs"`
 	Meta          ToolMeta         `json:"meta"`
 	AccessControl map[string]any   `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant    `json:"access_grants,omitempty"`
 	UpdatedAt     int64            `json:"updated_at"`
 	CreatedAt     int64            `json:"created_at"`
 }
@@ -52,6 +55,7 @@ type ToolAccessResponse struct {
 	Name          string         `json:"name"`
 	Meta          ToolMeta       `json:"meta"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 	UpdatedAt     int64          `json:"updated_at"`
 	CreatedAt     int64          `json:"created_at"`
 	User          *User          `json:"user,omitempty"`
@@ -65,6 +69,7 @@ type ToolUserResponse struct {
 	Name          string         `json:"name"`
 	Meta          ToolMeta       `json:"meta"`
 	AccessControl map[string]any `json:"access_control,omitempty"`
+	AccessGrants  []AccessGrant  `json:"access_grants,omitempty"`
 	UpdatedAt     int64          `json:"updated_at"`
 	CreatedAt     int64          `json:"created_at"`
 	User          *User          `json:"user,omitempty"`

--- a/internal/provider/access_control_helpers.go
+++ b/internal/provider/access_control_helpers.go
@@ -113,6 +113,11 @@ func fetchGroupNamesForIDs(ctx context.Context, apiClient *client.Client, ids []
 	return uniqueStrings(names), diags
 }
 
+// extractGroupIDsFromGrants returns unique group IDs holding the named permission.
+func extractGroupIDsFromGrants(grants []client.AccessGrant, permission string) []string {
+	return client.ExtractGroupIDs(grants, permission)
+}
+
 func buildAccessControl(readIDs, writeIDs []string) map[string]any {
 	if len(readIDs) == 0 && len(writeIDs) == 0 {
 		return nil

--- a/internal/provider/list_helpers.go
+++ b/internal/provider/list_helpers.go
@@ -30,8 +30,8 @@ func expandStringList(ctx context.Context, value types.List, attribute path.Path
 
 // flattenStringSlice converts a slice of strings into a Terraform List value.
 func flattenStringSlice(ctx context.Context, values []string) (types.List, diag.Diagnostics) {
-	if len(values) == 0 {
-		return types.ListNull(types.StringType), nil
+	if values == nil {
+		values = []string{}
 	}
 
 	list, diags := types.ListValueFrom(ctx, types.StringType, values)

--- a/internal/provider/resource_knowledge.go
+++ b/internal/provider/resource_knowledge.go
@@ -313,23 +313,10 @@ func knowledgeResponseToModel(ctx context.Context, apiClient *client.Client, res
 	readNames := readIDs
 	writeNames := writeIDs
 
-	readList := types.ListNull(types.StringType)
-	if len(readNames) > 0 {
-		l, listDiags := types.ListValueFrom(ctx, types.StringType, readNames)
-		diags.Append(listDiags...)
-		if !listDiags.HasError() {
-			readList = l
-		}
-	}
-
-	writeList := types.ListNull(types.StringType)
-	if len(writeNames) > 0 {
-		l, listDiags := types.ListValueFrom(ctx, types.StringType, writeNames)
-		diags.Append(listDiags...)
-		if !listDiags.HasError() {
-			writeList = l
-		}
-	}
+	readList, readListDiags := flattenStringSlice(ctx, readNames)
+	diags.Append(readListDiags...)
+	writeList, writeListDiags := flattenStringSlice(ctx, writeNames)
+	diags.Append(writeListDiags...)
 
 	model := knowledgeResourceModel{
 		ID:          types.StringValue(resp.ID),

--- a/internal/provider/resource_knowledge.go
+++ b/internal/provider/resource_knowledge.go
@@ -143,7 +143,6 @@ func (r *knowledgeResource) Create(ctx context.Context, req resource.CreateReque
 	readIDs := resolveGroupNamesToIDs(ctx, r.client, readNames, path.Root("read_groups"), &resp.Diagnostics)
 	writeIDs := resolveGroupNamesToIDs(ctx, r.client, writeNames, path.Root("write_groups"), &resp.Diagnostics)
 
-	form.AccessControl = buildAccessControl(readIDs, writeIDs)
 	form.Data = decodeOptionalJSON(plan.DataJSON, path.Root("data_json"), &resp.Diagnostics)
 	form.Meta = decodeOptionalJSON(plan.MetaJSON, path.Root("meta_json"), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -153,6 +152,11 @@ func (r *knowledgeResource) Create(ctx context.Context, req resource.CreateReque
 	created, err := r.client.CreateKnowledge(ctx, form)
 	if err != nil {
 		resp.Diagnostics.AddError("Create knowledge entry failed", err.Error())
+		return
+	}
+
+	if _, err := r.client.UpdateKnowledgeAccess(ctx, created.ID, client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+		resp.Diagnostics.AddError("Set knowledge access failed", err.Error())
 		return
 	}
 
@@ -228,7 +232,6 @@ func (r *knowledgeResource) Update(ctx context.Context, req resource.UpdateReque
 	readIDs := resolveGroupNamesToIDs(ctx, r.client, readNames, path.Root("read_groups"), &resp.Diagnostics)
 	writeIDs := resolveGroupNamesToIDs(ctx, r.client, writeNames, path.Root("write_groups"), &resp.Diagnostics)
 
-	form.AccessControl = buildAccessControl(readIDs, writeIDs)
 	form.Data = decodeOptionalJSON(plan.DataJSON, path.Root("data_json"), &resp.Diagnostics)
 	form.Meta = decodeOptionalJSON(plan.MetaJSON, path.Root("meta_json"), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -238,6 +241,11 @@ func (r *knowledgeResource) Update(ctx context.Context, req resource.UpdateReque
 	_, err := r.client.UpdateKnowledge(ctx, plan.ID.ValueString(), form)
 	if err != nil {
 		resp.Diagnostics.AddError("Update knowledge entry failed", err.Error())
+		return
+	}
+
+	if _, err := r.client.UpdateKnowledgeAccess(ctx, plan.ID.ValueString(), client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+		resp.Diagnostics.AddError("Set knowledge access failed", err.Error())
 		return
 	}
 
@@ -299,13 +307,11 @@ func knowledgeResponseToModel(ctx context.Context, apiClient *client.Client, res
 		diags.AddError("Serialize metadata", err.Error())
 	}
 
-	readIDs := extractGroupIDsFromAccessControl(resp.AccessControl, "read")
-	writeIDs := extractGroupIDsFromAccessControl(resp.AccessControl, "write")
+	readIDs := extractGroupIDsFromGrants(resp.AccessGrants, "read")
+	writeIDs := extractGroupIDsFromGrants(resp.AccessGrants, "write")
 
-	readNames, readDiags := fetchGroupNamesForIDs(ctx, apiClient, readIDs)
-	diags.Append(readDiags...)
-	writeNames, writeDiags := fetchGroupNamesForIDs(ctx, apiClient, writeIDs)
-	diags.Append(writeDiags...)
+	readNames := readIDs
+	writeNames := writeIDs
 
 	readList := types.ListNull(types.StringType)
 	if len(readNames) > 0 {

--- a/internal/provider/resource_model.go
+++ b/internal/provider/resource_model.go
@@ -156,9 +156,8 @@ func (r *modelResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 			},
 			"updated_at": schema.Int64Attribute{
-				Computed:      true,
-				Description:   "Unix timestamp indicating the last update time.",
-				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
+				Computed:    true,
+				Description: "Unix timestamp indicating the last update time.",
 			},
 			"meta_additional_json": schema.StringAttribute{
 				Optional:      true,
@@ -379,7 +378,6 @@ func (r *modelResource) Create(ctx context.Context, req resource.CreateRequest, 
 	writeNames := expandStringList(ctx, plan.WriteGroups, path.Root("write_groups"), &resp.Diagnostics)
 	readIDs := resolveGroupNamesToIDs(ctx, r.client, readNames, path.Root("read_groups"), &resp.Diagnostics)
 	writeIDs := resolveGroupNamesToIDs(ctx, r.client, writeNames, path.Root("write_groups"), &resp.Diagnostics)
-	form.AccessControl = buildAccessControl(readIDs, writeIDs)
 
 	if !plan.BaseModelID.IsNull() && !plan.BaseModelID.IsUnknown() && plan.BaseModelID.ValueString() != "" {
 		base := plan.BaseModelID.ValueString()
@@ -401,7 +399,18 @@ func (r *modelResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	state, diags := modelResponseToModel(ctx, r.client, created, plan.ModelID.ValueString())
+	if _, err := r.client.UpdateModelAccess(ctx, created.ID, client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+		resp.Diagnostics.AddError("Set model access failed", err.Error())
+		return
+	}
+
+	refreshed, err := r.client.GetModel(ctx, created.ID)
+	if err != nil {
+		resp.Diagnostics.AddError("Read model failed", err.Error())
+		return
+	}
+
+	state, diags := modelResponseToModel(ctx, r.client, refreshed, plan.ModelID.ValueString())
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -489,7 +498,6 @@ func (r *modelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	writeNames := expandStringList(ctx, plan.WriteGroups, path.Root("write_groups"), &resp.Diagnostics)
 	readIDs := resolveGroupNamesToIDs(ctx, r.client, readNames, path.Root("read_groups"), &resp.Diagnostics)
 	writeIDs := resolveGroupNamesToIDs(ctx, r.client, writeNames, path.Root("write_groups"), &resp.Diagnostics)
-	form.AccessControl = buildAccessControl(readIDs, writeIDs)
 
 	if !plan.BaseModelID.IsNull() && !plan.BaseModelID.IsUnknown() && plan.BaseModelID.ValueString() != "" {
 		base := plan.BaseModelID.ValueString()
@@ -508,6 +516,11 @@ func (r *modelResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	_, err := r.client.UpdateModel(ctx, plan.ID.ValueString(), form)
 	if err != nil {
 		resp.Diagnostics.AddError("Update model failed", err.Error())
+		return
+	}
+
+	if _, err := r.client.UpdateModelAccess(ctx, plan.ID.ValueString(), client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+		resp.Diagnostics.AddError("Set model access failed", err.Error())
 		return
 	}
 
@@ -564,13 +577,11 @@ func modelResponseToModel(ctx context.Context, apiClient *client.Client, resp *c
 	metaState, metaAdditional, metaDiags := flattenModelMeta(ctx, resp.Meta)
 	diags.Append(metaDiags...)
 
-	readIDs := extractGroupIDsFromAccessControl(resp.AccessControl, "read")
-	writeIDs := extractGroupIDsFromAccessControl(resp.AccessControl, "write")
+	readIDs := extractGroupIDsFromGrants(resp.AccessGrants, "read")
+	writeIDs := extractGroupIDsFromGrants(resp.AccessGrants, "write")
 
-	readNames, readDiags := fetchGroupNamesForIDs(ctx, apiClient, readIDs)
-	diags.Append(readDiags...)
-	writeNames, writeDiags := fetchGroupNamesForIDs(ctx, apiClient, writeIDs)
-	diags.Append(writeDiags...)
+	readNames := readIDs
+	writeNames := writeIDs
 
 	readList, readListDiags := flattenStringSlice(ctx, readNames)
 	diags.Append(readListDiags...)

--- a/internal/provider/resource_prompt.go
+++ b/internal/provider/resource_prompt.go
@@ -146,7 +146,6 @@ func (r *promptResource) Create(ctx context.Context, req resource.CreateRequest,
 	readIDs := resolveGroupNamesToIDs(ctx, r.client, readNames, path.Root("read_groups"), &resp.Diagnostics)
 	writeIDs := resolveGroupNamesToIDs(ctx, r.client, writeNames, path.Root("write_groups"), &resp.Diagnostics)
 
-	form.AccessControl = buildAccessControl(readIDs, writeIDs)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -155,6 +154,13 @@ func (r *promptResource) Create(ctx context.Context, req resource.CreateRequest,
 	if err != nil {
 		resp.Diagnostics.AddError("Create prompt failed", err.Error())
 		return
+	}
+
+	if created.ID != "" {
+		if _, err := r.client.UpdatePromptAccess(ctx, created.ID, client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+			resp.Diagnostics.AddError("Set prompt access failed", err.Error())
+			return
+		}
 	}
 
 	state, diags := promptResponseToModel(ctx, r.client, created)
@@ -236,7 +242,6 @@ func (r *promptResource) Update(ctx context.Context, req resource.UpdateRequest,
 	readIDs := resolveGroupNamesToIDs(ctx, r.client, readNames, path.Root("read_groups"), &resp.Diagnostics)
 	writeIDs := resolveGroupNamesToIDs(ctx, r.client, writeNames, path.Root("write_groups"), &resp.Diagnostics)
 
-	form.AccessControl = buildAccessControl(readIDs, writeIDs)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -245,6 +250,13 @@ func (r *promptResource) Update(ctx context.Context, req resource.UpdateRequest,
 	if err != nil {
 		resp.Diagnostics.AddError("Update prompt failed", err.Error())
 		return
+	}
+
+	if updatedPrompt.ID != "" {
+		if _, err := r.client.UpdatePromptAccess(ctx, updatedPrompt.ID, client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+			resp.Diagnostics.AddError("Set prompt access failed", err.Error())
+			return
+		}
 	}
 
 	state, diags := promptResponseToModel(ctx, r.client, updatedPrompt)
@@ -292,13 +304,11 @@ func (r *promptResource) ImportState(ctx context.Context, req resource.ImportSta
 func promptResponseToModel(ctx context.Context, apiClient *client.Client, resp *client.PromptModel) (promptResourceModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	readIDs := extractGroupIDsFromAccessControl(resp.AccessControl, "read")
-	writeIDs := extractGroupIDsFromAccessControl(resp.AccessControl, "write")
+	readIDs := extractGroupIDsFromGrants(resp.AccessGrants, "read")
+	writeIDs := extractGroupIDsFromGrants(resp.AccessGrants, "write")
 
-	readNames, readDiags := fetchGroupNamesForIDs(ctx, apiClient, readIDs)
-	diags.Append(readDiags...)
-	writeNames, writeDiags := fetchGroupNamesForIDs(ctx, apiClient, writeIDs)
-	diags.Append(writeDiags...)
+	readNames := readIDs
+	writeNames := writeIDs
 
 	readList := types.ListNull(types.StringType)
 	if len(readNames) > 0 {

--- a/internal/provider/resource_prompt.go
+++ b/internal/provider/resource_prompt.go
@@ -157,10 +157,12 @@ func (r *promptResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	if created.ID != "" {
-		if _, err := r.client.UpdatePromptAccess(ctx, created.ID, client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+		updatedGrants, err := r.client.UpdatePromptAccess(ctx, created.ID, client.BuildGroupGrants(readIDs, writeIDs))
+		if err != nil {
 			resp.Diagnostics.AddError("Set prompt access failed", err.Error())
 			return
 		}
+		created.AccessGrants = updatedGrants
 	}
 
 	state, diags := promptResponseToModel(ctx, r.client, created)
@@ -253,10 +255,12 @@ func (r *promptResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	if updatedPrompt.ID != "" {
-		if _, err := r.client.UpdatePromptAccess(ctx, updatedPrompt.ID, client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+		updatedGrants, err := r.client.UpdatePromptAccess(ctx, updatedPrompt.ID, client.BuildGroupGrants(readIDs, writeIDs))
+		if err != nil {
 			resp.Diagnostics.AddError("Set prompt access failed", err.Error())
 			return
 		}
+		updatedPrompt.AccessGrants = updatedGrants
 	}
 
 	state, diags := promptResponseToModel(ctx, r.client, updatedPrompt)
@@ -310,23 +314,10 @@ func promptResponseToModel(ctx context.Context, apiClient *client.Client, resp *
 	readNames := readIDs
 	writeNames := writeIDs
 
-	readList := types.ListNull(types.StringType)
-	if len(readNames) > 0 {
-		l, listDiags := types.ListValueFrom(ctx, types.StringType, readNames)
-		diags.Append(listDiags...)
-		if !listDiags.HasError() {
-			readList = l
-		}
-	}
-
-	writeList := types.ListNull(types.StringType)
-	if len(writeNames) > 0 {
-		l, listDiags := types.ListValueFrom(ctx, types.StringType, writeNames)
-		diags.Append(listDiags...)
-		if !listDiags.HasError() {
-			writeList = l
-		}
-	}
+	readList, readListDiags := flattenStringSlice(ctx, readNames)
+	diags.Append(readListDiags...)
+	writeList, writeListDiags := flattenStringSlice(ctx, writeNames)
+	diags.Append(writeListDiags...)
 
 	state := promptResourceModel{
 		ID:          types.StringValue(resp.Command),

--- a/internal/provider/resource_tool.go
+++ b/internal/provider/resource_tool.go
@@ -155,7 +155,7 @@ func (r *toolResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	form, diags := toolFormFromPlan(ctx, r.client, plan)
+	form, readIDs, writeIDs, diags := toolFormFromPlan(ctx, r.client, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -164,6 +164,11 @@ func (r *toolResource) Create(ctx context.Context, req resource.CreateRequest, r
 	created, err := r.client.CreateTool(ctx, form)
 	if err != nil {
 		resp.Diagnostics.AddError("Create tool failed", err.Error())
+		return
+	}
+
+	if _, err := r.client.UpdateToolAccess(ctx, created.ID, client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+		resp.Diagnostics.AddError("Set tool access failed", err.Error())
 		return
 	}
 
@@ -234,7 +239,7 @@ func (r *toolResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	form, diags := toolFormFromPlan(ctx, r.client, plan)
+	form, readIDs, writeIDs, diags := toolFormFromPlan(ctx, r.client, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -246,15 +251,19 @@ func (r *toolResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	access := &client.ToolAccessResponse{
-		ID:            updated.ID,
-		UserID:        updated.UserID,
-		Name:          updated.Name,
-		Meta:          updated.Meta,
-		AccessControl: updated.AccessControl,
-		UpdatedAt:     updated.UpdatedAt,
-		CreatedAt:     updated.CreatedAt,
+	if _, err := r.client.UpdateToolAccess(ctx, plan.ID.ValueString(), client.BuildGroupGrants(readIDs, writeIDs)); err != nil {
+		resp.Diagnostics.AddError("Set tool access failed", err.Error())
+		return
 	}
+
+	refreshed, err := r.client.GetTool(ctx, plan.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Read tool failed", err.Error())
+		return
+	}
+
+	access := refreshed
+	updated.AccessGrants = refreshed.AccessGrants
 
 	state, stateDiags := toolResponseToModel(ctx, r.client, access, updated.Content, updated.Specs, plan.Content)
 	resp.Diagnostics.Append(stateDiags...)
@@ -294,7 +303,7 @@ func (r *toolResource) ImportState(ctx context.Context, req resource.ImportState
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("tool_id"), req.ID)...)
 }
 
-func toolFormFromPlan(ctx context.Context, apiClient *client.Client, plan toolResourceModel) (client.ToolForm, diag.Diagnostics) {
+func toolFormFromPlan(ctx context.Context, apiClient *client.Client, plan toolResourceModel) (client.ToolForm, []string, []string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	manifest := decodeOptionalJSON(plan.ManifestJSON, path.Root("manifest_json"), &diags)
@@ -316,12 +325,11 @@ func toolFormFromPlan(ctx context.Context, apiClient *client.Client, plan toolRe
 	writeIDs := resolveGroupNamesToIDs(ctx, apiClient, writeNames, path.Root("write_groups"), &diags)
 
 	return client.ToolForm{
-		ID:            plan.ToolID.ValueString(),
-		Name:          plan.Name.ValueString(),
-		Content:       plan.Content.ValueString(),
-		Meta:          meta,
-		AccessControl: buildAccessControl(readIDs, writeIDs),
-	}, diags
+		ID:      plan.ToolID.ValueString(),
+		Name:    plan.Name.ValueString(),
+		Content: plan.Content.ValueString(),
+		Meta:    meta,
+	}, readIDs, writeIDs, diags
 }
 
 func fetchToolContent(ctx context.Context, apiClient *client.Client, toolID string) (string, []map[string]any, diag.Diagnostics) {
@@ -350,13 +358,11 @@ func toolResponseToModel(ctx context.Context, apiClient *client.Client, access *
 		return toolResourceModel{}, diags
 	}
 
-	readIDs := extractGroupIDsFromAccessControl(access.AccessControl, "read")
-	writeIDs := extractGroupIDsFromAccessControl(access.AccessControl, "write")
+	readIDs := extractGroupIDsFromGrants(access.AccessGrants, "read")
+	writeIDs := extractGroupIDsFromGrants(access.AccessGrants, "write")
 
-	readNames, readDiags := fetchGroupNamesForIDs(ctx, apiClient, readIDs)
-	diags.Append(readDiags...)
-	writeNames, writeDiags := fetchGroupNamesForIDs(ctx, apiClient, writeIDs)
-	diags.Append(writeDiags...)
+	readNames := readIDs
+	writeNames := writeIDs
 
 	readList, readListDiags := flattenStringSlice(ctx, readNames)
 	diags.Append(readListDiags...)


### PR DESCRIPTION
OpenWebUI's nested access_control field is silently dropped server-side in favour of the flat access_grants list. Each managed resource (model, knowledge, prompt, tool) now calls the dedicated /access/update endpoint after Create/Update and stores grants instead of the legacy structure.

Also normalize empty list state values so flattenStringSlice no longer collapses [] into null, which caused "inconsistent result after apply" errors when clearing read_groups/write_groups.